### PR TITLE
dnsprobe: add small binary to probe dns servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,21 @@ RUN cp -a /src/dnscrypt-proxy/example-* ./
 COPY dnscrypt-proxy.toml ./
 
 # ----------------------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:1.20.2 as probe
 
+WORKDIR /src/dnsprobe
+
+ARG TARGETOS TARGETARCH
+
+ADD dnsprobe/ ./
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /usr/local/bin/dnsprobe .
+
+# ----------------------------------------------------------------------------
 # hadolint ignore=DL3007
 FROM cgr.dev/chainguard/static:latest
 
 COPY --from=build /src/dnscrypt-proxy/dnscrypt-proxy /usr/local/bin/
+COPY --from=probe /usr/local/bin/dnsprobe /usr/local/bin/
 COPY --from=build --chown=nobody:nogroup /config /config
 
 # TODO: switch to 'nonroot' user

--- a/dnsprobe/dnsprobe.go
+++ b/dnsprobe/dnsprobe.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultPort = "53"
+
+func main() {
+	if len(os.Args) != 3 {
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s <name> <nameserver[:port]>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	host, portStr, err := net.SplitHostPort(os.Args[2])
+	if err != nil {
+		// TODO: This is a very bad way to check for an error, but `net.SplitHostPort` does not return a named error.
+		// Manually checking if os.Args[2] contains a port is harder than it seems due to having to handle v6 addresses.
+		if strings.Contains(err.Error(), "missing port in address") {
+			host = os.Args[2]
+			portStr = defaultPort
+		} else {
+			log.Fatalf("Cannot parse host[:port] from %q: %v", os.Args[2], err)
+		}
+	}
+
+	port, err := strconv.ParseInt(portStr, 10, 16)
+	if err != nil {
+		log.Fatalf("Cannot parse port %q: %v", portStr, err)
+	}
+
+	resolver := &net.Resolver{
+		PreferGo:     true,
+		StrictErrors: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return net.DialUDP("udp", nil, &net.UDPAddr{
+				IP:   net.ParseIP(host),
+				Port: int(port),
+			})
+		},
+	}
+
+	// TODO: Make timeout configurable.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	addrs, err := resolver.LookupHost(ctx, os.Args[1])
+	if err != nil {
+		log.Fatalf("Error looking up %q: %v", os.Args[1], err)
+	}
+
+	if len(addrs) == 0 {
+		log.Fatalf("Lookup for %q did not return any result", os.Args[1])
+	}
+
+	for _, addr := range addrs {
+		fmt.Println(addr)
+	}
+}

--- a/dnsprobe/go.mod
+++ b/dnsprobe/go.mod
@@ -1,0 +1,3 @@
+module github.com/klutchell/dnscrypt-proxy-docker/dnsprobe
+
+go 1.20

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,7 +37,7 @@ services:
         
         docker exec $${server_id} dnscrypt-proxy -version
 
-        docker exec $${server_id} dnsprobe dnssec.works 127.0.0.1:5053
+        docker exec $${server_id} dnsprobe -timeout=15s dnssec.works 127.0.0.1:5053
         ! docker exec $${server_id} dnsprobe foo.local 127.0.0.1:5053
         ! docker exec $${server_id} dnsprobe bar.local 127.0.0.1:5053
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,25 +9,40 @@ services:
       dockerfile: Dockerfile
     command: -config /config/dnscrypt-proxy.toml -loglevel 0
 
-  version:
-    image: localhost:5000/sut
-    build:
-      context: .
-      dockerfile: Dockerfile
-    command: -version
-
   sut:
     image: alpine:3.17
     depends_on:
       - server
-      - version
-    entrypoint: ""
-    command: >-
-      /bin/sh -c '
-      apk add --no-cache bind-tools &&
-      dig @server -p 5053 dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq NOERROR &&
-      dig @server -p 5053 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)" &&
-      dig @server -p 5053 fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)" &&
-      dig @server -p 5053 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)" &&
-      dig @server -p 5053 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)"
-      '
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /test
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - |
+        set -ex
+        apk add --no-cache bind-tools docker-cli docker-cli-compose
+
+        server_ip="$$(dig +short server | tail -n 1)"
+
+        while read id
+        do
+          if docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $${id} | grep -q "$${server_ip}"
+          then
+            server_id="$${id}"
+            break
+          fi
+        done < <(docker ps --format '{{.ID}}')
+        
+        docker exec $${server_id} dnscrypt-proxy -version
+
+        docker exec $${server_id} dnsprobe dnssec.works 127.0.0.1:5053
+        ! docker exec $${server_id} dnsprobe foo.local 127.0.0.1:5053
+        ! docker exec $${server_id} dnsprobe bar.local 127.0.0.1:5053
+
+        dig @server -p 5053 dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq NOERROR
+        dig @server -p 5053 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)"
+        dig @server -p 5053 fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)"
+        dig @server -p 5053 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)"
+        dig @server -p 5053 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep -qE "(SERVFAIL|no servers)"


### PR DESCRIPTION
This PR aims to solve #108 by adding a small go binary that resolves a given name on a given (udp) server, and fails if any error is encountered in the process.

This binary can be used as a readiness or health probe in environments like Kubernetes.