### PR TITLE
Improve consistency around ports in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ readinessProbe:
     command:
       - /usr/local/bin/dnsprobe
       - google.com
-      - 127.0.0.1:5353
+      - 127.0.0.1:5053
 livenessProbe:
   timeoutSeconds: 3
   failureThreshold: 3
@@ -85,7 +85,7 @@ livenessProbe:
     command:
       - /usr/local/bin/dnsprobe
       - google.com
-      - 127.0.0.1:5353
+      - 127.0.0.1:5053
 ```
 
 `dnsprobe` asks the nameserver supplied in the second argument to resolve the name supplied as the first argument. It will exit with non-zero code if:


### PR DESCRIPTION
First of all, thanks for maintaining this docker image.

Further up in the readme, port 53 is usually forwarded to 5053 instead of 5353 so I adjusted the liveness/readiness probe examples.

E.g. `docker run -p 53:5053/tcp -p 53:5053/udp klutchell/dnscrypt-proxy`