### PR TITLE
Use scratch base image and create nonroot user

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -32,6 +32,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       disable_versioning: true
+      toggle_auto_merge: false
       docker_images: |
         ghcr.io/klutchell/dnscrypt-proxy,
         docker.io/klutchell/dnscrypt-proxy


### PR DESCRIPTION
The cgr.dev/chainguard/static:latest image has dropped support for armv6