### PR TITLE
Add manual bump workflow for dnscrypt-proxy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["github>klutchell/renovate-config"]
+  "extends": ["github>klutchell/renovate-config"],
+  "packageRules": [
+    {
+      "description": "dnscrypt-proxy is bumped manually so the maintainer can sign and tag the release; see CONTRIBUTING.md",
+      "matchDatasources": ["github-tags", "github-releases"],
+      "matchPackageNames": ["DNSCrypt/dnscrypt-proxy"],
+      "enabled": false
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing
+
+We love your input! We want to make contributing to this project as easy and
+transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## We develop with Github
+
+We use Github to host code, to track issues and feature requests, as well as
+accept pull requests.
+
+## We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so all code changes happen through pull requests
+
+Pull requests are the best way to propose changes to the codebase. We actively
+welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+## Any contributions you make will be under the [Software License](LICENSE)
+
+In short, when you submit code changes, your submissions are understood to be
+under the same [Software License](LICENSE) that covers the project. Feel free
+to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/klutchell/dnscrypt-proxy-docker/issues)
+
+We use GitHub issues to track public bugs. Report a bug by
+[opening a new issue](https://github.com/klutchell/dnscrypt-proxy-docker/issues/new);
+it's that easy!
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you
+  tried that didn't work)
+
+People _love_ thorough bug reports. I'm not even kidding.
+
+## Use a consistent coding style
+
+- Use [hadolint](https://github.com/hadolint/hadolint) for linting and
+  validating Dockerfile changes
+- Use [prettier](https://prettier.io) for linting and validating Markdown
+  changes
+
+## Building
+
+1. Enable docker buildkit and experimental mode
+
+   ```bash
+   export DOCKER_BUILDKIT=1
+   export DOCKER_CLI_EXPERIMENTAL=enabled
+   ```
+
+2. Build image for host architecture
+
+   ```bash
+   docker build . --tag klutchell/dnscrypt-proxy:dev
+   ```
+
+3. Optionally cross-build for another architecture
+
+   ```bash
+   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+   docker build . --tag klutchell/dnscrypt-proxy:dev --platform linux/arm/v7
+   ```
+
+## Testing
+
+1. Run a detached dnscrypt-proxy container
+
+   ```bash
+   docker run --rm -d --name dnscrypt klutchell/dnscrypt-proxy:dev
+   ```
+
+2. Resolve a name through the proxy with the bundled `dnsprobe`
+
+   ```bash
+   docker exec dnscrypt dnsprobe -timeout=10s dnssec.works 127.0.0.1:5053
+   ```
+
+3. Stop and remove the test container
+
+   ```bash
+   docker stop dnscrypt
+   ```
+
+The full integration suite lives in [`docker-compose.test.yml`](docker-compose.test.yml)
+and runs in CI on every PR.
+
+## Packaging new dnscrypt-proxy releases
+
+The dnscrypt-proxy version is bumped manually (Renovate is explicitly disabled
+for this dependency) so the maintainer can verify upstream notes, recompute the
+source SHA256, and tag the release after merge.
+
+1. In your working copy, create a new branch if you haven't already, and update
+   the following fields in the [Dockerfile](Dockerfile) with the new version
+   and hash.
+
+   ```dockerfile
+   ARG DNSCRYPT_PROXY_VERSION=2.1.16
+   # https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.1.16
+   # sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/2.1.16.tar.gz
+   ARG DNSCRYPT_PROXY_SHA256="7ba5aa76d3fdc6fbb667689ba13d8ac3e66be27655695a9d412e5ad4afe34f8d"
+   ```
+
+   DNSCrypt does not publish a `.sha256` companion file for the GitHub source
+   archive, so compute it locally from the tarball you're pinning:
+
+   ```bash
+   curl -sL https://github.com/DNSCrypt/dnscrypt-proxy/archive/X.Y.Z.tar.gz | sha256sum
+   ```
+
+2. Run the following docker build command to regenerate the bundled example
+   configuration files from the new upstream source.
+
+   ```bash
+   export DOCKER_BUILDKIT=1
+   export DOCKER_CLI_EXPERIMENTAL=enabled
+   docker build . --target conf-example --output ./config
+   ```
+
+3. [Build](#building) and [test](#testing) changes locally.
+
+4. Commit and push changes to `Dockerfile` and any regenerated `config/example-*`
+   files.
+
+For the current pattern, see recent commits touching the dnscrypt-proxy `ARG`
+lines:
+
+```bash
+git log --oneline -- Dockerfile | grep -i dnscrypt-proxy | head -5
+```
+
+## Tagging a release (maintainers only)
+
+This section applies to repository maintainers. Contributors do not need to tag
+releases — the maintainer will tag once your bump PR is merged.
+
+After a dnscrypt-proxy bump PR is merged to `main`, tag the release on the
+**content commit** (the "Update dnscrypt-proxy to release X.Y.Z" commit), not
+the merge commit GitHub creates on top.
+
+```bash
+git fetch origin
+# Find the content commit on origin/main
+git log origin/main --grep='Update dnscrypt-proxy to release' --format='%H %s' -1
+
+# Create a signed, annotated tag with the version as the message body
+git tag -s vX.Y.Z -m "vX.Y.Z" <content-commit-sha>
+
+# Push the tag
+git push origin vX.Y.Z
+```
+
+Tags follow `vMAJOR.MINOR.PATCH` matching the upstream dnscrypt-proxy version,
+are annotated (not lightweight), and are GPG-signed. The tag message body is
+the bare version string — no release notes.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under its
+[Software License](LICENSE).
+
+## References
+
+This document was adapted from the open-source contribution guidelines for
+[Facebook's Draft](https://github.com/facebook/draft-js)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,17 @@ FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21@sha256:b4dbd292a0852331c
 
 WORKDIR /src
 
-# renovate: datasource=github-tags depName=DNSCrypt/dnscrypt-proxy
 ARG DNSCRYPT_PROXY_VERSION=2.1.16
+# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.1.16
+# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/2.1.16.tar.gz
+ARG DNSCRYPT_PROXY_SHA256="7ba5aa76d3fdc6fbb667689ba13d8ac3e66be27655695a9d412e5ad4afe34f8d"
 
 ADD https://github.com/DNSCrypt/dnscrypt-proxy/archive/${DNSCRYPT_PROXY_VERSION}.tar.gz /tmp/dnscrypt-proxy.tar.gz
 
-RUN tar xzf /tmp/dnscrypt-proxy.tar.gz --strip 1
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+RUN echo "${DNSCRYPT_PROXY_SHA256}  /tmp/dnscrypt-proxy.tar.gz" | sha256sum -c - \
+	&& tar xzf /tmp/dnscrypt-proxy.tar.gz --strip 1
 
 WORKDIR /src/dnscrypt-proxy
 

--- a/config/example-allowed-ips.txt
+++ b/config/example-allowed-ips.txt
@@ -5,3 +5,5 @@
 #192.168.0.*
 #fe80:53:*          # IPv6 prefix example
 #81.169.145.105
+#192.168.0.0/16     # CIDR network mask
+#fe80::/10          # IPv6 CIDR network mask

--- a/config/example-blocked-ips.txt
+++ b/config/example-blocked-ips.txt
@@ -15,3 +15,5 @@
 163.5.1.4
 94.46.118.*
 fe80:53:*          # IPv6 prefix example
+10.0.0.0/8         # CIDR network mask
+fe80::/10          # IPv6 CIDR network mask

--- a/config/example-cloaking-rules.txt
+++ b/config/example-cloaking-rules.txt
@@ -13,7 +13,7 @@ www.google.*             forcesafesearch.google.com
 
 www.bing.com             strict.bing.com
 
-yandex.ru                familysearch.yandex.ru       # inline comments are allowed after a pound sign
+=yandex.ru               familysearch.yandex.ru       # inline comments are allowed after a pound sign
 
 =duckduckgo.com          safe.duckduckgo.com
 

--- a/config/example-dnscrypt-proxy.toml
+++ b/config/example-dnscrypt-proxy.toml
@@ -189,7 +189,7 @@ keepalive = 30
 
 ## Set to `true` to constantly try to estimate the latency of all the resolvers
 ## and adjust the load-balancing parameters accordingly, or to `false` to disable.
-## Default is `true` that makes 'p2' `lb_strategy` work well.
+## Default is `true`, which makes the `wp2` `lb_strategy` work well.
 
 # lb_estimator = true
 
@@ -243,7 +243,7 @@ keepalive = 30
 
 ## Automatic log files rotation
 
-# Maximum log files size in MB - Set to 0 for unlimited.
+# Maximum log files size in MB - 0 uses the logger's default size limit.
 log_files_max_size = 10
 
 # How long to keep backup files, in days
@@ -257,8 +257,8 @@ log_files_max_backups = 1
 #                           Certificate Management                             #
 ###############################################################################
 
-## The maximum concurrency to reload certificates from the resolvers.
-## Default is 10.
+## The maximum concurrency to refresh resolvers (DNSCrypt, DoH, and ODoH).
+## Default is 10. Reduce this on constrained devices such as small routers.
 
 # cert_refresh_concurrency = 10
 
@@ -287,21 +287,13 @@ cert_refresh_delay = 240
 # tls_disable_session_tickets = false
 
 
-## DoH: Use TLS 1.2 and specific cipher suite instead of the server preference
-## 49199 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-## 49195 = TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-## 52392 = TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-## 52393 = TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-##
-## On non-Intel CPUs such as MIPS routers and ARM systems (Android, Raspberry Pi...),
-## uncommenting the following line may improve performance.
-## This may also help on Intel CPUs running 32-bit operating systems.
-## However, this can cause issues fetching sources or connecting to some HTTP servers,
-## and should not be set on regular CPUs.
-##
-## Keep tls_cipher_suite undefined to let the app automatically choose secure parameters.
+## Prefer RSA certificates over ECDSA for TLS connections.
+## When this is enabled, some servers may become impossible to use,
+## or may stop working later as they upgrade their configuration.
+## Changing this setting is generally not recommended, but it may
+## reduce CPU usage on small routers with slow CPUs.
 
-# tls_cipher_suite = [52392, 49199]
+# tls_prefer_rsa = false
 
 
 ## Log TLS key material to a file, for debugging purposes only.
@@ -533,7 +525,7 @@ cache_neg_max_ttl = 600
 ## Path of the DoH URL. This is not a file, but the part after the hostname
 ## in the URL. By convention, `/dns-query` is frequently chosen.
 ## For each `listen_address` the complete URL to access the server will be:
-## `https://<listen_address><path>` (ex: `https://127.0.0.1/dns-query`)
+## `https://<listen_address><path>` (ex: `https://127.0.0.1:3000/dns-query`)
 
 # path = '/dns-query'
 
@@ -560,6 +552,12 @@ cache_neg_max_ttl = 600
 
 
 ## Query log format (currently supported: tsv and ltsv)
+##
+## TSV format columns: timestamp, client_ip, query_name, query_type, return_code, duration, server, relay
+## LTSV format fields: time, host, message, type, return, cached, duration, server, relay
+##
+## The relay field shows the anonymizing relay name when using Anonymized DNS or ODoH,
+## or "-" when no relay is used.
 
 format = 'tsv'
 
@@ -748,16 +746,20 @@ format = 'tsv'
 ## Refer to the documentation for URLs of public sources.
 ##
 ## A prefix can be prepended to server names in order to
-## avoid collisions if different sources share the same for
+## avoid collisions if different sources share the same names for
 ## different servers. In that case, names listed in `server_names`
 ## must include the prefixes.
 ##
 ## If the `urls` property is missing, cache files and valid signatures
 ## must already be present. This doesn't prevent these cache files from
-## expiring after `refresh_delay` hours.
-## `refreshed_delay` must be in the [24..168] interval.
-## The minimum delay of 24 hours (1 day) avoids unnecessary requests to servers.
-## The maximum delay of 168 hours (1 week) ensures cache freshness.
+## expiring after `cache_ttl` hours.
+##
+## `refresh_delay` controls how often to download updates during normal operation.
+## Must be in the [24..168] interval (1 day to 1 week).
+##
+## `cache_ttl` controls how old the cache can be at startup before requiring
+## an immediate download. Defaults to 168 hours if not set.
+## Must be in [refresh_delay..168] interval.
 
 [sources]
 
@@ -767,6 +769,7 @@ format = 'tsv'
 urls = [
   'https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md',
   'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md',
+  'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/public-resolvers.md'
 ]
 cache_file = 'public-resolvers.md'
 minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
@@ -779,6 +782,7 @@ prefix = ''
 urls = [
   'https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/relays.md',
   'https://download.dnscrypt.info/resolvers-list/v3/relays.md',
+  'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/relays.md'
 ]
 cache_file = 'relays.md'
 minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
@@ -788,13 +792,13 @@ prefix = ''
 ### ODoH (Oblivious DoH) servers and relays
 
 # [sources.odoh-servers]
-#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-servers.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-servers.md']
+#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-servers.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-servers.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/odoh-servers.md']
 #   cache_file = 'odoh-servers.md'
 #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
 #   refresh_delay = 73
 #   prefix = ''
 # [sources.odoh-relays]
-#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-relays.md']
+#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-relays.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/odoh-relays.md']
 #   cache_file = 'odoh-relays.md'
 #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
 #   refresh_delay = 73
@@ -812,7 +816,7 @@ prefix = ''
 ### This is a subset of the `public-resolvers` list, so enabling both is useless.
 
 # [sources.parental-control]
-#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v3/parental-control.md']
+#   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v3/parental-control.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/parental-control.md']
 #   cache_file = 'parental-control.md'
 #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
 
@@ -838,7 +842,7 @@ prefix = ''
 ##
 ## Older versions of the `dnsdist` server software had a bug with queries larger
 ## than 1500 bytes. This is fixed since `dnsdist` version 1.5.0, but
-## some server may still run an outdated version.
+## some servers may still run an outdated version.
 ##
 ## The list below enables workarounds to make non-relayed usage more reliable
 ## until the servers are fixed.
@@ -986,6 +990,7 @@ algorithm = "none"
 ## - ipcrypt-deterministic: 32 hex chars (16 bytes) - Generate with: openssl rand -hex 16
 ## - ipcrypt-nd: 32 hex chars (16 bytes) - Generate with: openssl rand -hex 16
 ## - ipcrypt-ndx: 64 hex chars (32 bytes) - Generate with: openssl rand -hex 32
+## - ipcrypt-pfx: 64 hex chars (32 bytes) - Generate with: openssl rand -hex 32
 ## Example for deterministic/nd: key = "1234567890abcdef1234567890abcdef"
 ## Example for ndx: key = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 ## IMPORTANT: Keep this key secret

--- a/config/example-forwarding-rules.txt
+++ b/config/example-forwarding-rules.txt
@@ -10,6 +10,9 @@
 ## The following keywords can also be used instead of a server address:
 ## $BOOTSTRAP to use the default bootstrap resolvers
 ## $DHCP to use the default DNS resolvers provided by the DHCP server
+## $RESOLVCONF:<file> to use the resolvers specified in <file> (with
+##     resolv.conf syntax); only 'nameserver' lines are parsed, other
+##     options are ignored; name of <file> mustn't contain any commas (,)
 
 ## In order to enable this feature, the "forwarding_rules" property needs to
 ## be set to this file name inside the main configuration file.
@@ -27,10 +30,14 @@
 ## Forward *.local to the resolvers provided by the DHCP server
 # local            $DHCP
 
+## Forward *.localnet to the resolvers specified in '/etc/resolv.conf'
+# localnet         $RESOLVCONF:/etc/resolv.conf
+
 ## Forward *.internal to 192.168.1.1, and if it doesn't work, to the
-## DNS from the local DHCP server, and if it still doesn't work, to the
-## bootstrap resolvers
-# internal         192.168.1.1,$DHCP,$BOOTSTRAP
+## DNS from the local DHCP server, and if that doesn't work, to the
+## bootstrap resolvers, and if it still doesn't work, to the resolvers
+## specified in '/etc/resolv.conf'
+# internal         192.168.1.1,$DHCP,$BOOTSTRAP,$RESOLVCONF:/etc/resolv.conf
 
 ## Forward queries for example.com and *.example.com to 9.9.9.9 and 8.8.8.8
 # example.com      9.9.9.9,8.8.8.8


### PR DESCRIPTION
## Summary

Replaces Renovate-driven auto-bumps of `DNSCrypt/dnscrypt-proxy` with a manual maintainer workflow, modeled on the existing process in [`klutchell/unbound-docker`](https://github.com/klutchell/unbound-docker).

### Why

Renovate-only bumps have two gaps:

1. **No source integrity check.** The Dockerfile fetched `https://github.com/DNSCrypt/dnscrypt-proxy/archive/${VERSION}.tar.gz` with no SHA256 verification — a silent supply-chain risk if GitHub's archive endpoint ever served unexpected bytes.
2. **No example-config regeneration.** This image bundles `config/example-*` files extracted from the upstream source via the `conf-example` build stage. Renovate's bumps only updated `ARG DNSCRYPT_PROXY_VERSION` and never re-ran the extraction, so the bundled examples drifted from the actually-pinned upstream. The most user-visible drift: `example-dnscrypt-proxy.toml` on `main` was still documenting the removed `tls_cipher_suite` option from earlier 2.1.x releases, even though upstream replaced it with `tls_prefer_rsa`.

### What changes

- **`Dockerfile`** — pins `DNSCRYPT_PROXY_SHA256` for `2.1.16` and verifies it with `sha256sum -c` before extracting the tarball. Builds now fail fast if the upstream archive bytes change unexpectedly.
- **`.github/renovate.json`** — explicit `packageRules` entry disabling Renovate for `DNSCrypt/dnscrypt-proxy` (so a future contributor doesn't "fix" the missing renovate marker by re-enabling it). The renovate marker comment has also been removed from the Dockerfile.
- **`CONTRIBUTING.md`** — new file documenting build/test/bump/tag processes, matching the structure of `unbound-docker`'s.
- **`config/example-*`** — regenerated from upstream 2.1.16 via `docker build . --target conf-example --output ./config`. Brings the bundled examples back in sync with the pinned upstream version.

The actual 2.1.16 version bump landed in #646; this PR is the workflow infrastructure that future X.Y.Z bumps will use. `v2.1.16` has been tagged on the content commit as part of putting this workflow into practice.

## Test plan

- [x] `docker build . --tag klutchell/dnscrypt-proxy:dev` succeeds with SHA256 verification active
- [x] `docker run --rm klutchell/dnscrypt-proxy:dev --version` prints `2.1.16`
- [x] Build with a deliberately-wrong SHA256 fails at the verification step (exit 1) — confirms the check actually rejects mismatches
- [x] `docker build . --target conf-example --output ./config` regenerates example files cleanly
- [x] Pre-commit hooks pass (hadolint, renovate-config-validator, trailing-whitespace, end-of-file-fixer)
- [ ] CI passes the full integration suite in `docker-compose.test.yml`
