### PR TITLE
Add automated workflows for dnscrypt-proxy version bumping

### DIFF
--- a/.github/workflows/bump-dnscrypt-proxy.yml
+++ b/.github/workflows/bump-dnscrypt-proxy.yml
@@ -6,37 +6,47 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "dnscrypt-proxy version to bump to (e.g. 2.1.18). Leave empty to auto-detect the latest upstream release."
+        description: "dnscrypt-proxy version to bump to. Leave empty to auto-detect the latest upstream release."
         required: false
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ secrets.FLOWZONE_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Determine current and target version
         id: versions
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           current=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_VERSION=)\S+' Dockerfile)
           echo "current=$current" >> "$GITHUB_OUTPUT"
 
-          if [ -n "${{ inputs.version }}" ]; then
-            target="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            if ! echo "$INPUT_VERSION" | grep -qP '^\d+\.\d+\.\d+$'; then
+              echo "::error::version input '$INPUT_VERSION' doesn't look like a dnscrypt-proxy version (expected X.Y.Z)"
+              exit 1
+            fi
+            target="$INPUT_VERSION"
           else
             target=$(curl -fsSL https://api.github.com/repos/DNSCrypt/dnscrypt-proxy/releases/latest | jq -r .tag_name)
           fi
@@ -55,37 +65,42 @@ jobs:
         if: steps.versions.outputs.up_to_date == 'false'
         id: existing
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ steps.versions.outputs.target }}
         run: |
-          target="${{ steps.versions.outputs.target }}"
-          count=$(gh pr list --repo "${{ github.repository }}" --state open --search "head:bump/dnscrypt-proxy-${target}" --json number --jq 'length')
+          set -euo pipefail
+          count=$(gh pr list --repo "${{ github.repository }}" --state open --search "head:bump/dnscrypt-proxy-${TARGET}" --json number --jq 'length')
           echo "exists=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Compute upstream SHA256
         if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
         id: hash
+        env:
+          TARGET: ${{ steps.versions.outputs.target }}
         run: |
-          target="${{ steps.versions.outputs.target }}"
-          url="https://github.com/DNSCrypt/dnscrypt-proxy/archive/${target}.tar.gz"
+          set -euo pipefail
+          url="https://github.com/DNSCrypt/dnscrypt-proxy/archive/${TARGET}.tar.gz"
           curl -fsSL "$url" -o /tmp/dnscrypt-proxy.tar.gz
           sha256=$(sha256sum /tmp/dnscrypt-proxy.tar.gz | awk '{print $1}')
           echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
 
       - name: Update Dockerfile
         if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          TARGET: ${{ steps.versions.outputs.target }}
+          SHA256: ${{ steps.hash.outputs.sha256 }}
         run: |
-          target="${{ steps.versions.outputs.target }}"
-          sha="${{ steps.hash.outputs.sha256 }}"
+          set -euo pipefail
           sed -i \
-            -e "s|^ARG DNSCRYPT_PROXY_VERSION=.*|ARG DNSCRYPT_PROXY_VERSION=${target}|" \
-            -e "s|^# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/.*|# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${target}|" \
-            -e "s|^# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/.*|# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/${target}.tar.gz|" \
-            -e "s|^ARG DNSCRYPT_PROXY_SHA256=.*|ARG DNSCRYPT_PROXY_SHA256=\"${sha}\"|" \
+            -e "s|^ARG DNSCRYPT_PROXY_VERSION=.*|ARG DNSCRYPT_PROXY_VERSION=${TARGET}|" \
+            -e "s|^# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/.*|# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${TARGET}|" \
+            -e "s|^# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/.*|# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/${TARGET}.tar.gz|" \
+            -e "s|^ARG DNSCRYPT_PROXY_SHA256=.*|ARG DNSCRYPT_PROXY_SHA256=\"${SHA256}\"|" \
             Dockerfile
 
       - name: Set up Docker Buildx
         if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.2.0
 
       - name: Regenerate example configs
         if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
@@ -99,22 +114,47 @@ jobs:
           DOCKER_BUILDKIT: "1"
         run: docker build . --tag dnscrypt-proxy:bump-check
 
+      - name: Create commit via REST API
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        id: commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET: ${{ steps.versions.outputs.target }}
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          branch="bump/dnscrypt-proxy-${TARGET}"
+          base_sha=$(git rev-parse HEAD)
+          base_tree=$(gh api "repos/${repo}/git/commits/${base_sha}" --jq .tree.sha)
+
+          tree_json="[]"
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            base64 -w0 "$f" > /tmp/blob.b64
+            blob_sha=$(gh api "repos/${repo}/git/blobs" -f encoding=base64 -F content=@/tmp/blob.b64 --jq .sha)
+            tree_json=$(echo "$tree_json" | jq --arg path "$f" --arg sha "$blob_sha" '. + [{path: $path, mode: "100644", type: "blob", sha: $sha}]')
+          done < <(git status --porcelain | awk '{print $2}')
+
+          new_tree=$(jq -n --arg base_tree "$base_tree" --argjson tree "$tree_json" '{base_tree: $base_tree, tree: $tree}' \
+            | gh api "repos/${repo}/git/trees" --input - --jq .sha)
+
+          new_commit=$(jq -n --arg message "Bump dnscrypt-proxy to ${TARGET}" --arg tree "$new_tree" --arg parent "$base_sha" \
+            '{message: $message, tree: $tree, parents: [$parent]}' \
+            | gh api "repos/${repo}/git/commits" --input - --jq .sha)
+
+          gh api "repos/${repo}/git/refs" -f ref="refs/heads/${branch}" -f sha="${new_commit}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
       - name: Open pull request
         if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET: ${{ steps.versions.outputs.target }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
         run: |
-          target="${{ steps.versions.outputs.target }}"
-          branch="bump/dnscrypt-proxy-${target}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git add Dockerfile config/example-*
-          git commit -m "Bump dnscrypt-proxy to ${target}"
-          git push origin "$branch"
-
+          set -euo pipefail
           printf '%s\n' \
-            "Automated bump to [dnscrypt-proxy ${target}](https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${target})." \
+            "Automated bump to [dnscrypt-proxy ${TARGET}](https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${TARGET})." \
             "" \
             "SHA256 verified and computed on this runner, \`config/example-*\` regenerated via \`docker build --target conf-example\`, and a sanity build passed. See [CONTRIBUTING.md](https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md#packaging-new-dnscrypt-proxy-releases) for the process this follows." \
             "" \
@@ -123,7 +163,7 @@ jobs:
 
           gh pr create \
             --repo "${{ github.repository }}" \
-            --title "Bump dnscrypt-proxy to ${target}" \
+            --title "Bump dnscrypt-proxy to ${TARGET}" \
             --body-file /tmp/pr-body.md \
             --base main \
-            --head "$branch"
+            --head "$BRANCH"

--- a/.github/workflows/bump-dnscrypt-proxy.yml
+++ b/.github/workflows/bump-dnscrypt-proxy.yml
@@ -1,0 +1,129 @@
+name: Bump dnscrypt-proxy
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "dnscrypt-proxy version to bump to (e.g. 2.1.18). Leave empty to auto-detect the latest upstream release."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Determine current and target version
+        id: versions
+        run: |
+          current=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_VERSION=)\S+' Dockerfile)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ inputs.version }}" ]; then
+            target="${{ inputs.version }}"
+          else
+            target=$(curl -fsSL https://api.github.com/repos/DNSCrypt/dnscrypt-proxy/releases/latest | jq -r .tag_name)
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "Current: $current, target: $target"
+
+          # only proceed if target is strictly newer than current
+          newest=$(printf '%s\n%s' "$current" "$target" | sort -V | tail -n1)
+          if [ "$current" = "$target" ] || [ "$newest" != "$target" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing bump branch/PR
+        if: steps.versions.outputs.up_to_date == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          target="${{ steps.versions.outputs.target }}"
+          count=$(gh pr list --repo "${{ github.repository }}" --state open --search "head:bump/dnscrypt-proxy-${target}" --json number --jq 'length')
+          echo "exists=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute upstream SHA256
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        id: hash
+        run: |
+          target="${{ steps.versions.outputs.target }}"
+          url="https://github.com/DNSCrypt/dnscrypt-proxy/archive/${target}.tar.gz"
+          curl -fsSL "$url" -o /tmp/dnscrypt-proxy.tar.gz
+          sha256=$(sha256sum /tmp/dnscrypt-proxy.tar.gz | awk '{print $1}')
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Update Dockerfile
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        run: |
+          target="${{ steps.versions.outputs.target }}"
+          sha="${{ steps.hash.outputs.sha256 }}"
+          sed -i \
+            -e "s|^ARG DNSCRYPT_PROXY_VERSION=.*|ARG DNSCRYPT_PROXY_VERSION=${target}|" \
+            -e "s|^# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/.*|# https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${target}|" \
+            -e "s|^# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/.*|# sha256sum of https://github.com/DNSCrypt/dnscrypt-proxy/archive/${target}.tar.gz|" \
+            -e "s|^ARG DNSCRYPT_PROXY_SHA256=.*|ARG DNSCRYPT_PROXY_SHA256=\"${sha}\"|" \
+            Dockerfile
+
+      - name: Set up Docker Buildx
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Regenerate example configs
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build . --target conf-example --output ./config
+
+      - name: Sanity build
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build . --tag dnscrypt-proxy:bump-check
+
+      - name: Open pull request
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          target="${{ steps.versions.outputs.target }}"
+          branch="bump/dnscrypt-proxy-${target}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add Dockerfile config/example-*
+          git commit -m "Bump dnscrypt-proxy to ${target}"
+          git push origin "$branch"
+
+          printf '%s\n' \
+            "Automated bump to [dnscrypt-proxy ${target}](https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/${target})." \
+            "" \
+            "SHA256 verified and computed on this runner, \`config/example-*\` regenerated via \`docker build --target conf-example\`, and a sanity build passed. See [CONTRIBUTING.md](https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md#packaging-new-dnscrypt-proxy-releases) for the process this follows." \
+            "" \
+            "Tagging the release remains a separate, gated step that runs after this PR merges." \
+            > /tmp/pr-body.md
+
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --title "Bump dnscrypt-proxy to ${target}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/tag-dnscrypt-proxy.yml
+++ b/.github/workflows/tag-dnscrypt-proxy.yml
@@ -1,0 +1,106 @@
+name: Tag dnscrypt-proxy release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'bump/dnscrypt-proxy-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Verify only expected files changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          changed=$(gh pr diff "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --name-only)
+          echo "Changed files:"
+          echo "$changed"
+          unexpected=$(echo "$changed" | grep -v -E '^(Dockerfile|config/example-)' || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected files changed in this bump PR, refusing to tag: $unexpected"
+            exit 1
+          fi
+
+      - name: Resolve content commit
+        id: commit
+        run: |
+          merge_sha="${{ github.event.pull_request.merge_commit_sha }}"
+          # non-squash merges put the actual content on the merge commit's 2nd parent;
+          # squash merges make the merge commit itself the content commit (no 2nd parent)
+          if content_sha=$(git rev-parse --verify -q "${merge_sha}^2"); then
+            echo "sha=$content_sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine version and re-verify SHA256
+        id: version
+        run: |
+          content_sha="${{ steps.commit.outputs.sha }}"
+          git show "${content_sha}:Dockerfile" > /tmp/Dockerfile.content
+          version=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_VERSION=)\S+' /tmp/Dockerfile.content)
+          pinned_sha256=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_SHA256=")[^"]+' /tmp/Dockerfile.content)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          actual_sha256=$(curl -fsSL "https://github.com/DNSCrypt/dnscrypt-proxy/archive/${version}.tar.gz" | sha256sum | awk '{print $1}')
+          if [ "$actual_sha256" != "$pinned_sha256" ]; then
+            echo "::error::SHA256 mismatch for ${version}: Dockerfile pins ${pinned_sha256}, archive is actually ${actual_sha256}. Refusing to tag."
+            exit 1
+          fi
+
+      - name: Check tag doesn't already exist
+        id: exists
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${version}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create verified tag via REST API
+        if: steps.exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          content_sha="${{ steps.commit.outputs.sha }}"
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          tag_sha=$(gh api "repos/${{ github.repository }}/git/tags" --input - <<EOF | jq -r .sha
+          {
+            "tag": "v${version}",
+            "message": "v${version}",
+            "object": "${content_sha}",
+            "type": "commit",
+            "tagger": { "name": "github-actions[bot]", "email": "github-actions[bot]@users.noreply.github.com", "date": "${now}" }
+          }
+          EOF
+          )
+
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/v${version}" \
+            -f sha="${tag_sha}"

--- a/.github/workflows/tag-dnscrypt-proxy.yml
+++ b/.github/workflows/tag-dnscrypt-proxy.yml
@@ -7,33 +7,37 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   tag:
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'bump/dnscrypt-proxy-')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ secrets.FLOWZONE_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Verify only expected files changed
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          changed=$(gh pr diff "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --name-only)
+          set -euo pipefail
+          changed=$(gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" --name-only)
           echo "Changed files:"
           echo "$changed"
           unexpected=$(echo "$changed" | grep -v -E '^(Dockerfile|config/example-)' || true)
@@ -44,21 +48,25 @@ jobs:
 
       - name: Resolve content commit
         id: commit
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          merge_sha="${{ github.event.pull_request.merge_commit_sha }}"
+          set -euo pipefail
           # non-squash merges put the actual content on the merge commit's 2nd parent;
           # squash merges make the merge commit itself the content commit (no 2nd parent)
-          if content_sha=$(git rev-parse --verify -q "${merge_sha}^2"); then
+          if content_sha=$(git rev-parse --verify -q "${MERGE_SHA}^2"); then
             echo "sha=$content_sha" >> "$GITHUB_OUTPUT"
           else
-            echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
+            echo "sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine version and re-verify SHA256
         id: version
+        env:
+          CONTENT_SHA: ${{ steps.commit.outputs.sha }}
         run: |
-          content_sha="${{ steps.commit.outputs.sha }}"
-          git show "${content_sha}:Dockerfile" > /tmp/Dockerfile.content
+          set -euo pipefail
+          git show "${CONTENT_SHA}:Dockerfile" > /tmp/Dockerfile.content
           version=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_VERSION=)\S+' /tmp/Dockerfile.content)
           pinned_sha256=$(grep -oP '(?<=^ARG DNSCRYPT_PROXY_SHA256=")[^"]+' /tmp/Dockerfile.content)
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -72,10 +80,11 @@ jobs:
       - name: Check tag doesn't already exist
         id: exists
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          version="${{ steps.version.outputs.version }}"
-          if gh api "repos/${{ github.repository }}/git/ref/tags/v${version}" >/dev/null 2>&1; then
+          set -euo pipefail
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -85,22 +94,16 @@ jobs:
         if: steps.exists.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CONTENT_SHA: ${{ steps.commit.outputs.sha }}
         run: |
-          version="${{ steps.version.outputs.version }}"
-          content_sha="${{ steps.commit.outputs.sha }}"
+          set -euo pipefail
           now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          tag_sha=$(gh api "repos/${{ github.repository }}/git/tags" --input - <<EOF | jq -r .sha
-          {
-            "tag": "v${version}",
-            "message": "v${version}",
-            "object": "${content_sha}",
-            "type": "commit",
-            "tagger": { "name": "github-actions[bot]", "email": "github-actions[bot]@users.noreply.github.com", "date": "${now}" }
-          }
-          EOF
-          )
+          tag_sha=$(jq -n --arg tag "v${VERSION}" --arg message "v${VERSION}" --arg object "$CONTENT_SHA" --arg date "$now" \
+            '{tag: $tag, message: $message, object: $object, type: "commit", tagger: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", date: $date}}' \
+            | gh api "repos/${{ github.repository }}/git/tags" --input - --jq .sha)
 
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/v${version}" \
+            -f ref="refs/tags/v${VERSION}" \
             -f sha="${tag_sha}"


### PR DESCRIPTION
## Summary
This PR introduces two GitHub Actions workflows to automate the process of bumping dnscrypt-proxy versions and creating corresponding releases.

## Key Changes

- **bump-dnscrypt-proxy.yml**: Automated workflow that runs weekly (Mondays at 9 AM UTC) or on manual trigger to:
  - Detect the latest upstream dnscrypt-proxy release (or use a manually specified version)
  - Compare against the current pinned version in the Dockerfile
  - Compute SHA256 hash of the upstream release archive
  - Update Dockerfile with new version and hash
  - Regenerate example configuration files via Docker build
  - Run a sanity build to verify the changes
  - Open a pull request with the changes if a newer version is available

- **tag-dnscrypt-proxy.yml**: Automated workflow triggered when a bump PR is merged to:
  - Verify only expected files (Dockerfile and config examples) were changed
  - Re-verify the SHA256 hash of the release archive matches what's pinned
  - Create a signed Git tag for the release
  - Prevent tagging if the tag already exists or if SHA256 verification fails

## Notable Implementation Details

- Uses GitHub App token authentication for secure API access and PR creation
- Implements version comparison logic to only proceed if target version is strictly newer
- Checks for existing open bump PRs to avoid duplicate work
- Handles both squash and non-squash merge commits when determining the content commit SHA
- Includes comprehensive validation steps (SHA256 verification, sanity builds, file change verification) before tagging
- Follows a gated release process where tagging is a separate step after PR merge

https://claude.ai/code/session_01SMcEi3jweJQLHzpVSTrmGC