### PR TITLE
Fix Flowzone app token input and bump golang base image

### DIFF
--- a/.github/workflows/bump-dnscrypt-proxy.yml
+++ b/.github/workflows/bump-dnscrypt-proxy.yml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{ secrets.FLOWZONE_APP_ID }}
+          client-id: ${{ vars.FLOWZONE_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/tag-dnscrypt-proxy.yml
+++ b/.github/workflows/tag-dnscrypt-proxy.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{ secrets.FLOWZONE_APP_ID }}
+          client-id: ${{ vars.FLOWZONE_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21@sha256:b4dbd292a0852331c89dfd64e84d16811f3e3aae4c73c13d026c4d200715aff6 AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine3.24@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
 
 WORKDIR /src
 
@@ -43,7 +43,7 @@ FROM scratch AS conf-example
 COPY --from=build /config/example-* /
 
 # ----------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21@sha256:b4dbd292a0852331c89dfd64e84d16811f3e3aae4c73c13d026c4d200715aff6 AS probe
+FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine3.24@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS probe
 
 WORKDIR /src/dnsprobe
 


### PR DESCRIPTION
## Summary

- `create-github-app-token` renamed its `app-id` input to `client-id`, and app IDs aren't sensitive, so both bump/tag workflows now use `client-id: ${{ vars.FLOWZONE_APP_ID }}` instead of `app-id: ${{ secrets.FLOWZONE_APP_ID }}`.
- The scheduled bump workflow's config-regeneration step failed against dnscrypt-proxy 2.1.18: its `go.mod` now requires `go >= 1.25.8`, which the pinned `golang:1.25.5-alpine3.21` base can't satisfy under `GOTOOLCHAIN=local`. Bumped both the `build` and `probe` stages to `golang:1.25.12-alpine3.24` (the latest patch that satisfies the requirement — 3.21 has no patch release that new), with the digest verified against the registry.

The workflow's own sanity-build step caught this correctly and failed before reaching the commit/PR steps, so no broken PR was left behind.

## Test plan

- [x] YAML validated and `check-yaml`/whitespace pre-commit hooks pass on both workflow files
- [x] New golang digest verified against `registry-1.docker.io`
- [ ] CI passes the full build/test suite on this PR
- [ ] Next scheduled or manually-dispatched bump run gets through config regeneration and sanity build

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMcEi3jweJQLHzpVSTrmGC)_