### PR TITLE
Reference nonroot by numeric uid in USER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+ARG NONROOT_UID=65532
+ARG NONROOT_GID=65532
+
 FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 
 WORKDIR /src
@@ -30,8 +33,8 @@ RUN cp -a /src/dnscrypt-proxy/example-* ./ \
 
 COPY config/dnscrypt-proxy.toml ./
 
-ARG NONROOT_UID=65532
-ARG NONROOT_GID=65532
+ARG NONROOT_UID
+ARG NONROOT_GID
 
 RUN addgroup -S -g ${NONROOT_GID} nonroot \
 	&& adduser -S -g nonroot -h /home/nonroot -u ${NONROOT_UID} -D -G nonroot nonroot
@@ -63,7 +66,9 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=nonroot:nonroot /home/nonroot /home/nonroot
 COPY --from=build --chown=nonroot:nonroot /config /config
 
-USER nonroot
+ARG NONROOT_UID
+
+USER ${NONROOT_UID}
 
 ENV PATH=$PATH:/usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ docker run -p 53:5053/tcp -p 53:5053/udp klutchell/dnscrypt-proxy
 
 # run dnscrypt proxy server with configuration mounted from a host directory
 # note that the files in the configuration directory '/path/to/config' must be
-# readable by world, or owned by nobody:nogroup, and the directory itself must be
-# writeable by world, or owned by nobody:nogroup
+# readable by world, or owned by nonroot:nonroot (65532:65532), and the directory
+# itself must be writeable by world, or owned by nonroot:nonroot (65532:65532)
 docker run -p 53:5053/udp -v /path/to/config:/config klutchell/dnscrypt-proxy
 ```
 


### PR DESCRIPTION
Declare NONROOT_UID/NONROOT_GID once as global build args and re-declare them bare in each stage. The final stage carried its own ARG default, so changing one and missing the other would emit a USER uid with no /etc/passwd entry while /config was chowned to the other uid.

Using the numeric uid also avoids "DL3066 info: Non-numeric user-id may not be resolvable by host system".

Correct the README while here: a mounted config dir needs nonroot (65532), not nobody:nogroup (65534).