### PR TITLE
Wait for dnscrypt-proxy readiness instead of sleeping

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -38,7 +38,23 @@ services:
 
         docker exec $${server_id} dnscrypt-proxy -version
 
-        sleep 5
+        # Wait until the proxy answers instead of guessing at a duration.
+        # Startup is network-bound: dnscrypt-proxy fetches the resolver list,
+        # verifies its signature, then probes every server in it before one is
+        # usable. A fixed sleep raced that and failed about half the time.
+        ready=
+        attempt=0
+        while [ $${attempt} -lt 30 ]
+        do
+          if docker exec $${server_id} dnsprobe -timeout=2s example.com 127.0.0.1:5053
+          then
+            ready=1
+            break
+          fi
+          attempt=$$((attempt + 1))
+          sleep 2
+        done
+        test -n "$${ready}"
 
         docker exec $${server_id} dnsprobe -timeout=10s dnssec.works 127.0.0.1:5053
         ! docker exec $${server_id} dnsprobe foo.local 127.0.0.1:5053


### PR DESCRIPTION
The docker tests gated on a fixed `sleep 5`, but dnscrypt-proxy's startup is network-bound: it fetches public-resolvers.md and relays.md over HTTPS, verifies their signatures, then probes every server in the list before any is usable. `server_names` is unpinned, so that is the whole public resolver list -- 472 probe results in one observed job, still arriving 19s after start.

Five seconds was not enough about half the time. Two failing jobs on the same day: on arm/v6 the first test (`dnsprobe dnssec.works`) timed out after 10.4s; on arm64 `dig sigok.verteiltesysteme.net` got three `communications error ... timed out` over 15s while the proxy was still probing. Neither logged the readiness notice from serversInfo.go ("Server with the lowest initial latency: ... live servers: N") -- and neither did the passing job, which simply got lucky and hit an already-probed server mid-ranking. Re-running just re-rolled the dice.

Poll with the repo's own dnsprobe until the proxy actually answers, capped at 30 attempts (~2 min), and fail if it never does. Exhaustion still fails the job, so a genuine hang is not masked. No config change, so the shipped default config stays under test.